### PR TITLE
fix(ci): deploy live hosting to badminton-ledger-prod

### DIFF
--- a/.github/workflows/firebase-hosting-live.yml
+++ b/.github/workflows/firebase-hosting-live.yml
@@ -39,6 +39,6 @@ jobs:
         uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: ${{ secrets.GITHUB_TOKEN }}
-          firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
+          firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_PROD }}
           channelId: live
-          projectId: badminton-ledger
+          projectId: badminton-ledger-prod

--- a/firestore.rules
+++ b/firestore.rules
@@ -22,6 +22,7 @@ service cloud.firestore {
     match /transactions/{doc}          { allow read, write: if isAdmin(); }
     match /balanceLedger/{doc}         { allow read, write: if isAdmin(); }
     match /archivedSessions/{doc}      { allow read, write: if isAdmin(); }
+    match /payouts/{doc}               { allow read, write: if isAdmin(); }
 
     // ── Admin membership ───────────────────────────────────────────────────────
     // Signed-in users may read (so the app can check their own admin status),


### PR DESCRIPTION
The build was switched to the prod Firebase config (PROD_* secrets) but the deploy still targeted the old badminton-ledger project, so the live site was served from a domain not authorized for the prod project's Auth -> Google sign-in failed with auth/unauthorized-domain. Point the deploy at badminton-ledger-prod with a prod service account so build and hosting match.