### PR TITLE
fix(ci): use PROD_FIREBASE_SERVICE_ACCOUNT secret name

### DIFF
--- a/.github/workflows/firebase-hosting-live.yml
+++ b/.github/workflows/firebase-hosting-live.yml
@@ -39,6 +39,6 @@ jobs:
         uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: ${{ secrets.GITHUB_TOKEN }}
-          firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_PROD }}
+          firebaseServiceAccount: ${{ secrets.PROD_FIREBASE_SERVICE_ACCOUNT }}
           channelId: live
           projectId: badminton-ledger-prod


### PR DESCRIPTION
Align the live deploy step with the actual repo secret name (PROD_ prefix, matching the PROD_REACT_APP_FIREBASE_* build secrets). Fixes the action failing with 'Input required and not supplied: firebaseServiceAccount'.