### PR TITLE
Redirect unauthenticated users to the account page

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -15,7 +15,7 @@ import { subscribeToPlayers } from './features/players/playersSlice';
 import { useAppDispatch, useAppSelector } from './hooks';
 import { setCurrentClubId } from './services/firebase/client';
 import { useClubBootstrap } from './features/club/useClubBootstrap';
-import { selectCurrentClubId, selectClubReady, selectClubRole } from './features/club/clubSlice';
+import { selectCurrentClubId, selectClubReady, selectClubRole, selectSignedIn } from './features/club/clubSlice';
 
 function ClubLoading() {
   return (
@@ -25,12 +25,14 @@ function ClubLoading() {
   );
 }
 
-// Requires a selected club; otherwise sends the user to the account page to pick one.
+// Requires a signed-in user with a selected club; otherwise sends the user to the
+// account page to sign in and/or pick a club.
 function RequireClub({ children }: { children: React.ReactElement }) {
   const ready = useAppSelector(selectClubReady);
+  const signedIn = useAppSelector(selectSignedIn);
   const clubId = useAppSelector(selectCurrentClubId);
   if (!ready) return <ClubLoading />;
-  if (!clubId) return <Navigate to="/auth" replace />;
+  if (!signedIn || !clubId) return <Navigate to="/auth" replace />;
   return children;
 }
 

--- a/ui/src/features/club/clubSlice.ts
+++ b/ui/src/features/club/clubSlice.ts
@@ -7,6 +7,7 @@ interface ClubState {
   role: ClubRole | null;      // the signed-in user's role in the current club
   clubs: UserClub[];          // the user's saved clubs (name + role)
   disabledTabs: string[];     // tab keys hidden for the current club
+  signedIn: boolean;          // an authenticated user is present
   ready: boolean;             // club bootstrap has finished
 }
 
@@ -15,6 +16,7 @@ const initialState: ClubState = {
   role: null,
   clubs: [],
   disabledTabs: [],
+  signedIn: false,
   ready: false,
 };
 
@@ -34,6 +36,9 @@ const clubSlice = createSlice({
     setDisabledTabs(state, action: PayloadAction<string[]>) {
       state.disabledTabs = action.payload;
     },
+    setSignedIn(state, action: PayloadAction<boolean>) {
+      state.signedIn = action.payload;
+    },
     setReady(state, action: PayloadAction<boolean>) {
       state.ready = action.payload;
     },
@@ -43,13 +48,14 @@ const clubSlice = createSlice({
   },
 });
 
-export const { setCurrentClub, setRole, setClubs, setDisabledTabs, setReady, resetClub } = clubSlice.actions;
+export const { setCurrentClub, setRole, setClubs, setDisabledTabs, setSignedIn, setReady, resetClub } = clubSlice.actions;
 export default clubSlice.reducer;
 
 export const selectCurrentClubId = (s: RootState) => s.club.currentClubId;
 export const selectClubRole      = (s: RootState) => s.club.role;
 export const selectUserClubs     = (s: RootState) => s.club.clubs;
 export const selectDisabledTabs  = (s: RootState) => s.club.disabledTabs;
+export const selectSignedIn      = (s: RootState) => s.club.signedIn;
 export const selectClubReady     = (s: RootState) => s.club.ready;
 export const selectIsClubAdmin   = (s: RootState) => s.club.role === 'admin' || s.club.role === 'superAdmin';
 export const selectIsClubSuperAdmin = (s: RootState) => s.club.role === 'superAdmin';

--- a/ui/src/features/club/useClubBootstrap.ts
+++ b/ui/src/features/club/useClubBootstrap.ts
@@ -16,6 +16,7 @@ import {
   setCurrentClub,
   setRole,
   setDisabledTabs,
+  setSignedIn,
   setReady,
   resetClub,
   selectCurrentClubId,
@@ -43,6 +44,8 @@ export function useClubBootstrap(): void {
         dispatch(resetClub());
         return;
       }
+
+      dispatch(setSignedIn(true));
 
       const clubParam = searchParams.get('club');
       if (clubParam) {


### PR DESCRIPTION
RequireClub only checked for a selected club, so a not-signed-in visitor could reach app content. Track a signedIn flag from the auth listener and require it (plus a club) before rendering club routes.