### PR TITLE
Allow cost-only sessions when the players tab is disabled [ untested ]

### DIFF
--- a/ui/src/components/Calander/SessionCalendar.tsx
+++ b/ui/src/components/Calander/SessionCalendar.tsx
@@ -6,8 +6,8 @@ import { getMonth, getYear, lastDayOfMonth } from "date-fns";
 import { useSearchParams } from "react-router-dom";
 
 import { useAppDispatch, useAppSelector } from "../../hooks";
-import { selectModalMode, setMode } from "../../features/SessionModal/sessionModalSlice";
-import { selectCurrentClubId } from "../../features/club/clubSlice";
+import { selectModalMode, setMode, setConfirmedPlayers } from "../../features/SessionModal/sessionModalSlice";
+import { selectCurrentClubId, selectDisabledTabs } from "../../features/club/clubSlice";
 import { fetchSessions, fetchSessionById, addSession, editSession, deleteSession } from "../../services/firebase";
 import { getMonthYear, getNextMonth, getPrevMonth } from "../../utils/dateUtils";
 import type { Session } from "../../types";
@@ -27,6 +27,7 @@ export default function SessionCalendar({ onSessionsChanged }: { onSessionsChang
     const [isLoading, setIsLoading] = useState(false);
     const modalMode = useAppSelector(selectModalMode);
     const currentClubId = useAppSelector(selectCurrentClubId);
+    const playersEnabled = !useAppSelector(selectDisabledTabs).includes("players");
     const dispatch = useAppDispatch();
     const [searchParams, setSearchParams] = useSearchParams();
 
@@ -84,7 +85,14 @@ export default function SessionCalendar({ onSessionsChanged }: { onSessionsChang
         if (!selectedDate) return;
         setClickedDate(selectedDate);
         setModalSession(undefined);
-        dispatch(setMode("paste"));
+        // With players disabled, skip the name paste/resolve steps and go straight to a
+        // cost-only session form (no attendees).
+        if (playersEnabled) {
+            dispatch(setMode("paste"));
+        } else {
+            dispatch(setConfirmedPlayers([]));
+            dispatch(setMode("details"));
+        }
         setShowModal(true);
     };
 

--- a/ui/src/components/Calander/SessionModal.tsx
+++ b/ui/src/components/Calander/SessionModal.tsx
@@ -12,6 +12,7 @@ import {
     selectResolutionItems,
 } from "../../features/SessionModal/sessionModalSlice";
 import { findPlayersByName } from "../../services/firebase/players";
+import { selectDisabledTabs } from "../../features/club/clubSlice";
 import type { Session, NameResolutionItem, ConfirmedPlayer } from "../../types";
 import { formatPlayerName } from "../../services/firebase/players";
 
@@ -41,6 +42,7 @@ const MODAL_TITLES: Record<string, string> = {
 export default function SessionModal({ show, onHide, session, onSessionUpdate, onSaveSession, onDeleteSession }: Props) {
     const dispatch = useAppDispatch();
     const mode = useAppSelector(selectModalMode);
+    const playersEnabled = !useAppSelector(selectDisabledTabs).includes("players");
 
     // Reset when modal closes
     useEffect(() => {
@@ -112,8 +114,9 @@ export default function SessionModal({ show, onHide, session, onSessionUpdate, o
         [onSaveSession, onHide],
     );
 
-    const title = MODAL_TITLES[mode] ?? "Session Details";
-
+    const title = !playersEnabled && mode === "details"
+        ? "Add Session"
+        : MODAL_TITLES[mode] ?? "Session Details";
     return (
         <Modal show={show} onHide={onHide} centered size="lg">
             <Modal.Header closeButton>
@@ -142,7 +145,18 @@ export default function SessionModal({ show, onHide, session, onSessionUpdate, o
                         }}
                     />
                 )}
-                {mode === "view" && !session?.id && <NoSessionView onAddSession={() => dispatch(setMode("paste"))} />}
+                {mode === "view" && !session?.id && (
+                    <NoSessionView
+                        onAddSession={() => {
+                            if (playersEnabled) {
+                                dispatch(setMode("paste"));
+                            } else {
+                                dispatch(setConfirmedPlayers([]));
+                                dispatch(setMode("details"));
+                            }
+                        }}
+                    />
+                )}
             </Modal.Body>
         </Modal>
     );

--- a/ui/src/components/Calander/steps/SessionDetailsStep.tsx
+++ b/ui/src/components/Calander/steps/SessionDetailsStep.tsx
@@ -13,6 +13,7 @@ import {
 } from '../../../features/SessionModal/sessionModalSlice';
 
 import { selectPlayerById, selectAllPlayers } from '../../../features/players/playersSlice';
+import { selectDisabledTabs } from '../../../features/club/clubSlice';
 import { fetchBirdieInventory, fetchCourtCredits } from '../../../services/firebase';
 import { addPlayer } from '../../../services/firebase/players';
 import AddPlayerModal from '../../AddPlayerModal';
@@ -58,6 +59,8 @@ export default function SessionDetailsStep({ session, onSave, onCancel }: Props)
   const confirmedPlayers  = useAppSelector(selectConfirmedPlayers);
   const addError          = useAppSelector(selectAddError);
   const allPlayers        = useAppSelector(selectAllPlayers);
+  const disabledTabs      = useAppSelector(selectDisabledTabs);
+  const playersEnabled    = !disabledTabs.includes('players');
   const [playerToAdd, setPlayerToAdd] = useState('');
   const [showNewPlayerModal, setShowNewPlayerModal] = useState(false);
 
@@ -203,43 +206,47 @@ export default function SessionDetailsStep({ session, onSave, onCancel }: Props)
       {addError && <Alert variant="danger">{addError}</Alert>}
 
       {/* ── Players ─────────────────────────────────────────────────────── */}
-      <Row className="fw-bold mb-1">
-        <Col md={6}>Player</Col>
-        <Col md={4}>Cost / Fraction</Col>
-      </Row>
-      {playerCosts.map((player, i) => (
-        <PlayerRow
-          key={player.id}
-          playerId={player.id}
-          cost={player.cost}
-          percentage={player.percentage}
-          onPercentageChange={v => handlePercentageChange(player.id, v)}
-          onRemove={() => dispatch(setConfirmedPlayers(confirmedPlayers.filter(p => p.id !== player.id)))}
-        />
-      ))}
+      {playersEnabled && (
+        <>
+          <Row className="fw-bold mb-1">
+            <Col md={6}>Player</Col>
+            <Col md={4}>Cost / Fraction</Col>
+          </Row>
+          {playerCosts.map((player, i) => (
+            <PlayerRow
+              key={player.id}
+              playerId={player.id}
+              cost={player.cost}
+              percentage={player.percentage}
+              onPercentageChange={v => handlePercentageChange(player.id, v)}
+              onRemove={() => dispatch(setConfirmedPlayers(confirmedPlayers.filter(p => p.id !== player.id)))}
+            />
+          ))}
 
-      <Row className="mb-3">
-        <Col md={9}>
-          <InputGroup size="sm">
-            <Form.Select value={playerToAdd} onChange={e => setPlayerToAdd(e.target.value)}>
-              <option value="">+ Add existing player…</option>
-              {allPlayers
-                .filter(p => !confirmedPlayers.some(cp => cp.id === p.id))
-                .map(p => (
-                  <option key={p.id} value={p.id}>
-                    {[p.firstName, p.lastName].filter(Boolean).join(' ')}
-                  </option>
-                ))}
-            </Form.Select>
-            <Button variant="outline-primary" disabled={!playerToAdd} onClick={handleAddPlayer}>
-              Add
-            </Button>
-            <Button variant="outline-success" onClick={() => setShowNewPlayerModal(true)}>
-              + New player
-            </Button>
-          </InputGroup>
-        </Col>
-      </Row>
+          <Row className="mb-3">
+            <Col md={9}>
+              <InputGroup size="sm">
+                <Form.Select value={playerToAdd} onChange={e => setPlayerToAdd(e.target.value)}>
+                  <option value="">+ Add existing player…</option>
+                  {allPlayers
+                    .filter(p => !confirmedPlayers.some(cp => cp.id === p.id))
+                    .map(p => (
+                      <option key={p.id} value={p.id}>
+                        {[p.firstName, p.lastName].filter(Boolean).join(' ')}
+                      </option>
+                    ))}
+                </Form.Select>
+                <Button variant="outline-primary" disabled={!playerToAdd} onClick={handleAddPlayer}>
+                  Add
+                </Button>
+                <Button variant="outline-success" onClick={() => setShowNewPlayerModal(true)}>
+                  + New player
+                </Button>
+              </InputGroup>
+            </Col>
+          </Row>
+        </>
+      )}
 
       {/* ── Courts ──────────────────────────────────────────────────────── */}
       <Form.Group className="my-3">


### PR DESCRIPTION
When the Players tab is turned off in club settings, skip the paste/ resolve attendee steps and open the session form directly with no players. The form hides the roster and per-player cost section, and the session is saved with an empty players array (inventory still tracked, no per-player balances).