### PR TITLE
Fix balance-charge undo; split prepaid balance from session debt (owed) [untested]

### DIFF
--- a/ui/src/Pages/AttendancePage.tsx
+++ b/ui/src/Pages/AttendancePage.tsx
@@ -157,6 +157,12 @@ export default function AttendancePage() {
                   <strong className={player.balance < 0 ? 'text-danger' : 'text-success'}>
                     {money(player.balance)}
                   </strong>
+                  {(player.owed ?? 0) > 0 && (
+                    <>
+                      {' · '}Owed:{' '}
+                      <strong className="text-danger">{money(player.owed ?? 0)}</strong>
+                    </>
+                  )}
                 </span>
               )}
             </Card.Body>

--- a/ui/src/Pages/HomePage.tsx
+++ b/ui/src/Pages/HomePage.tsx
@@ -26,7 +26,7 @@ export default function HomePage() {
     const currentSession = sessions[sessionIndex] ?? null;
 
     const maxDisplay = 5;
-    const negativeBalancePlayers = players.filter((p) => p.balance < 0);
+    const negativeBalancePlayers = players.filter((p) => (p.owed ?? 0) > 0);
     const displayedPlayers = negativeBalancePlayers.slice(0, maxDisplay);
     const remainingCount = negativeBalancePlayers.length - displayedPlayers.length;
 
@@ -106,7 +106,7 @@ export default function HomePage() {
                                                     {player.firstName} {player.lastName ?? ""}
                                                 </Link>{" "}
                                                 —{" "}
-                                                <strong>${Math.abs(player.balance).toFixed(2)}</strong>
+                                                <strong>${(player.owed ?? 0).toFixed(2)}</strong>
                                             </li>
                                         ))}
                                     </ul>

--- a/ui/src/Pages/PlayersPage.tsx
+++ b/ui/src/Pages/PlayersPage.tsx
@@ -298,6 +298,7 @@ console.log("selectedPlayer ==> ", selectedPlayer);
       session_add:       'Session',
       'session-edit':    'Edit',
       session_edit:      'Edit',
+      'session-deleted': 'Session removed',
       payment:           'Payment',
       comp:              'Comp',
       settlement:        'Settlement',
@@ -306,6 +307,10 @@ console.log("selectedPlayer ==> ", selectedPlayer);
     };
     return map[reason] ?? reason;
   };
+
+  // The Balance History shows prepaid-wallet movements only. e-Transfer/comp
+  // settlements never touch the wallet, so they belong in the payout ledger, not here.
+  const walletLedger = ledger.filter(e => e.reason !== 'payment' && e.reason !== 'comp');
 
   return (
     <Container fluid className="mt-4">
@@ -343,9 +348,9 @@ console.log("selectedPlayer ==> ", selectedPlayer);
                     className="d-flex justify-content-between align-items-center"
                   >
                     <span>{formatPlayerName(player)}</span>
-                    {player.balance < 0 && (
+                    {(player.owed ?? 0) > 0 && (
                       <Badge bg="danger" style={{ fontSize: 10 }}>
-                        ${Math.abs(player.balance).toFixed(2)} owed
+                        ${(player.owed ?? 0).toFixed(2)} owed
                       </Badge>
                     )}
                   </ListGroup.Item>
@@ -429,11 +434,17 @@ console.log("selectedPlayer ==> ", selectedPlayer);
                           ${(selectedPlayer.balance ?? 0).toFixed(2)}
                         </span>
                         <small className="text-muted ms-2" style={{ fontSize: 13 }}>
-                          {selectedPlayer.balance > 0 ? '(Credit)'
-                            : selectedPlayer.balance < 0 ? '(Owes)' : ''}
+                          {selectedPlayer.balance > 0 ? '(Prepaid credit)'
+                            : selectedPlayer.balance < 0 ? '(Overdrawn)' : ''}
                         </small>
                       </h4>
-                      <p className="small text-muted mb-0">
+                      <h5 className="mb-0">Owed for sessions</h5>
+                      <h4>
+                        <span className={(selectedPlayer.owed ?? 0) > 0 ? 'text-danger' : 'text-success'}>
+                          ${(selectedPlayer.owed ?? 0).toFixed(2)}
+                        </span>
+                      </h4>
+                      <p className="small text-muted mb-0 mt-1">
                         Total Sessions attended: {selectedPlayer.sessionCount ?? 0}
                       </p>
                       <p className="small text-muted mb-0">
@@ -504,10 +515,10 @@ console.log("selectedPlayer ==> ", selectedPlayer);
                     <div className="text-center"><Spinner animation="border" size="sm" /></div>
                   )}
                   {ledgerError && <Alert variant="danger" className="small">{ledgerError}</Alert>}
-                  {!isLoadingLedger && ledger.length === 0 && (
+                  {!isLoadingLedger && walletLedger.length === 0 && (
                     <p className="text-muted small mb-0">No balance history yet.</p>
                   )}
-                  {!isLoadingLedger && ledger.length > 0 && (
+                  {!isLoadingLedger && walletLedger.length > 0 && (
                     <Table size="sm" borderless className="mb-0">
                       <thead>
                         <tr className="small text-muted">
@@ -519,7 +530,7 @@ console.log("selectedPlayer ==> ", selectedPlayer);
                         </tr>
                       </thead>
                       <tbody>
-                        {ledger.map(entry => (
+                        {walletLedger.map(entry => (
                           <tr key={entry.id} style={{ fontSize: 13 }}>
                             <td className="text-muted">
                               {entry.createdAt?.toDate

--- a/ui/src/components/Calander/steps/ExistingSessionView.tsx
+++ b/ui/src/components/Calander/steps/ExistingSessionView.tsx
@@ -148,10 +148,9 @@ function PlayerRow({
   const currentVia: PaidVia =
     player.paidVia ?? (player.comped ? 'comp' : player.paid ? 'etransfer' : null);
 
-  // Choosing 'balance' draws the session cost from prepaid credit; the session debit
-  // stands, so it can leave the player negative. Compute the resulting balance to warn.
-  const settledCredit = currentVia === 'etransfer' || currentVia === 'comp' ? player.cost : 0;
-  const balanceIfDrawn = (stored?.balance ?? 0) - settledCredit;
+  // Choosing 'balance' draws the session cost from prepaid credit, which can leave the
+  // player negative. Compute the resulting balance to warn.
+  const balanceIfDrawn = (stored?.balance ?? 0) - (currentVia === 'balance' ? 0 : player.cost);
 
   const handleSelect = (method: PaidVia) => {
     if (method === currentVia) return;

--- a/ui/src/components/Calander/steps/SessionDetailsStep.tsx
+++ b/ui/src/components/Calander/steps/SessionDetailsStep.tsx
@@ -134,14 +134,19 @@ export default function SessionDetailsStep({ session, onSave, onCancel }: Props)
   const playerCosts: SessionPlayer[] = useMemo(() => {
     const totalPercentage = confirmedPlayers.reduce((s, p) => s + p.percentage, 0);
     const perUnit         = totalPercentage > 0 ? totalSessionCost / totalPercentage : 0;
-    return confirmedPlayers.map(p => ({
-      id:         p.id,
-      percentage: p.percentage,
-      cost:       parseFloat((perUnit * p.percentage).toFixed(2)),
-      paid:       false,
-      highlighted: false,
-    }));
-  }, [confirmedPlayers, totalSessionCost]);
+    return confirmedPlayers.map(p => {
+      const existing = session?.players.find(sp => sp.id === p.id);
+      return {
+        id:          p.id,
+        percentage:  p.percentage,
+        cost:        parseFloat((perUnit * p.percentage).toFixed(2)),
+        paid:        existing?.paid ?? false,
+        paidVia:     existing?.paidVia ?? null,
+        comped:      existing?.comped ?? false,
+        highlighted: existing?.highlighted ?? false,
+      };
+    });
+  }, [confirmedPlayers, totalSessionCost, session]);
 
   // ── Handlers ───────────────────────────────────────────────────────────────
 

--- a/ui/src/services/firebase/players.ts
+++ b/ui/src/services/firebase/players.ts
@@ -69,6 +69,7 @@ export async function addPlayer(input: NewPlayerInput): Promise<string> {
       lastNameLower:  input.lastName ? input.lastName.toLowerCase() : null,
       email:          input.email ?? null,
       balance:        input.balance ?? 0,
+      owed:           0,
       description:    input.description ?? '',
       sessionCount:   0,
       createdAt:      serverTimestamp(),

--- a/ui/src/services/firebase/sessions.ts
+++ b/ui/src/services/firebase/sessions.ts
@@ -73,7 +73,7 @@ export async function fetchSessionById(sessionId: string): Promise<Session> {
  *  1. Creates the session document
  *  2. Deducts birds from each birdie batch
  *  3. Deducts hours from each court credit batch
- *  4. Decrements each player's balance by their cost
+ *  4. Draws the prepaid balance only for players settling via 'balance'
  *  5. Increments each player's sessionCount by 1 (replaces attendedSessionIds push)
  *  6. Logs a transaction record for each resource used
  */
@@ -177,22 +177,27 @@ export async function addSession(data: NewSessionData): Promise<string> {
       });
 
       // ── 6. Update player balances + session counts ────────────────────────────────
-      data.players.forEach((player, i) => {
+      resolvedPlayers.forEach((player, i) => {
+        const drawsWallet = player.paidVia === 'balance';
+        const owesForSession = !player.paid && !player.comped;
         const before = (playerDocs[i].data()?.balance as number) ?? 0;
         tx.update(playerDocs[i].ref, {
-          balance:      increment(-player.cost),  // debit the cost
-          sessionCount: increment(1),             // replaces pushing to attendedSessionIds
+          sessionCount: increment(1),
+          ...(drawsWallet ? { balance: increment(-player.cost) } : {}),
+          ...(owesForSession ? { owed: increment(player.cost) } : {}),
         });
-        tx.set(doc(refs.balanceLedger), {
-          playerId:      player.id,
-          sessionId:     sessionRef.id,
-          delta:         -player.cost,
-          balanceBefore: before,
-          balanceAfter:  before - player.cost,
-          reason:        'session',
-          note:          `Session on ${data.date.toLocaleDateString()}`,
-          createdAt:     serverTimestamp(),
-        });
+        if (drawsWallet) {
+          tx.set(doc(refs.balanceLedger), {
+            playerId:      player.id,
+            sessionId:     sessionRef.id,
+            delta:         -player.cost,
+            balanceBefore: before,
+            balanceAfter:  before - player.cost,
+            reason:        'session',
+            note:          `Session on ${data.date.toLocaleDateString()}`,
+            createdAt:     serverTimestamp(),
+          });
+        }
       });
     });
 
@@ -248,18 +253,11 @@ export async function editSession(
       const courtMap   = new Map([...allCourtIds].map((id, i)  => [id, courtSnaps[i]]));
       const playerMap  = new Map([...allPlayerIds].map((id, i) => [id, playerSnaps[i]]));
 
-      // A player whose positive (prepaid) balance covers their session cost has
-      // effectively paid. Measure the balance on the same basis as addSession by
-      // reversing this session's currently-applied debit (an unsettled player was
-      // debited their old cost at creation), then auto-mark paid when it covers the
-      // new cost. editSession adjusts balances by cost delta regardless of paid
-      // state, so flipping this flag has no balance side effect.
+      // A player whose positive prepaid balance covers their session cost is
+      // auto-settled from that balance, matching addSession.
       const resolvedPlayers = updatedData.players.map((player) => {
-        const before    = (playerMap.get(player.id)?.data()?.balance as number) ?? 0;
-        const oldPlayer = original.players.find(p => p.id === player.id);
-        const appliedDebit = oldPlayer && !oldPlayer.paid && !oldPlayer.comped ? (oldPlayer.cost ?? 0) : 0;
-        const available = before + appliedDebit;
-        const coveredByBalance = available > 0 && player.cost > 0 && player.cost <= available;
+        const before = (playerMap.get(player.id)?.data()?.balance as number) ?? 0;
+        const coveredByBalance = before > 0 && player.cost > 0 && player.cost <= before;
         return coveredByBalance && !player.paid && !player.comped
           ? { ...player, paid: true, paidVia: 'balance' as const }
           : player;
@@ -323,36 +321,68 @@ export async function editSession(
       });
 
       // ── Player balance + membership deltas ─────────────────────────────────────────
-      // Every player is debited their cost at creation, so any cost change (including
-      // players added to or removed from the session) must adjust the balance, and the
-      // sessionCount must track membership — regardless of paid state.
       allPlayerIds.forEach(id => {
         const snap      = playerMap.get(id)!;
         if (!snap.exists()) return;
         const oldPlayer = original.players.find(p => p.id === id);
-        const newPlayer = updatedData.players.find(p => p.id === id);
+        const newPlayer = resolvedPlayers.find(p => p.id === id);
 
-        const oldCost   = oldPlayer?.cost ?? 0;
-        const newCost   = newPlayer?.cost ?? 0;
-        const costDelta = newCost - oldCost;
+        const viaOf = (p?: SessionPlayer): PaidVia =>
+          p ? (p.paidVia ?? (p.comped ? 'comp' : p.paid ? 'etransfer' : null)) : null;
+        const oldVia  = viaOf(oldPlayer);
+        const newVia  = viaOf(newPlayer);
+        const oldCost = oldPlayer?.cost ?? 0;
+        const newCost = newPlayer?.cost ?? 0;
+
+        const walletDelta  = (oldVia === 'balance' ? oldCost : 0) - (newVia === 'balance' ? newCost : 0);
+        const owedDelta    = (newPlayer && newVia === null ? newCost : 0) - (oldPlayer && oldVia === null ? oldCost : 0);
+        const paymentDelta = (newVia === 'etransfer' ? newCost : 0) - (oldVia === 'etransfer' ? oldCost : 0);
+        const compDelta    = (newVia === 'comp' ? newCost : 0) - (oldVia === 'comp' ? oldCost : 0);
         const membershipDelta = (newPlayer ? 1 : 0) - (oldPlayer ? 1 : 0);
-        if (costDelta === 0 && membershipDelta === 0) return;
+        if (walletDelta === 0 && owedDelta === 0 && paymentDelta === 0 && compDelta === 0 && membershipDelta === 0) return;
 
         const before = (snap.data()?.balance as number) ?? 0;
         tx.update(snap.ref, {
-          balance: increment(-costDelta),
+          ...(walletDelta !== 0 ? { balance: increment(walletDelta) } : {}),
+          ...(owedDelta !== 0 ? { owed: increment(owedDelta) } : {}),
           ...(membershipDelta !== 0 ? { sessionCount: increment(membershipDelta) } : {}),
         });
 
-        if (costDelta !== 0) {
+        if (walletDelta !== 0) {
           tx.set(doc(refs.balanceLedger), {
             playerId:      id,
             sessionId,
-            delta:         -costDelta,
+            delta:         walletDelta,
             balanceBefore: before,
-            balanceAfter:  before - costDelta,
+            balanceAfter:  before + walletDelta,
             reason:        'session-edit',
-            note:          `Session edit (${oldCost.toFixed(2)} → ${newCost.toFixed(2)})`,
+            note:          'Session edit',
+            createdAt:     serverTimestamp(),
+          });
+        }
+        // Payout adjustments are wallet-neutral: they only re-price the owner payout
+        // when a settled player's cost changes during the edit.
+        if (paymentDelta !== 0) {
+          tx.set(doc(refs.balanceLedger), {
+            playerId:      id,
+            sessionId,
+            delta:         paymentDelta,
+            balanceBefore: before,
+            balanceAfter:  before,
+            reason:        'payment',
+            note:          'Session edit adjustment',
+            createdAt:     serverTimestamp(),
+          });
+        }
+        if (compDelta !== 0) {
+          tx.set(doc(refs.balanceLedger), {
+            playerId:      id,
+            sessionId,
+            delta:         compDelta,
+            balanceBefore: before,
+            balanceAfter:  before,
+            reason:        'comp',
+            note:          'Session edit adjustment',
             createdAt:     serverTimestamp(),
           });
         }
@@ -491,14 +521,13 @@ export async function togglePlayerCompStatus(
 }
 
 /**
- * Sets how a player's session cost was settled, adjusting their balance for the
- * change between the old and new method. The session's cost debit is permanent;
- * methods differ only by an extra settlement credit:
- *   - 'etransfer' → +cost logged as 'payment' (money owed to the owner)
- *   - 'comp'      → +cost logged as 'comp'    (excluded from the owner payout)
- *   - 'balance'   → no extra entry; the session debit is drawn from prepaid credit
- *   - null        → unpaid; no extra entry, the player owes the cost
- * 'balance' may leave the player negative (the caller warns first) and never affects payout.
+ * Sets how a player's session cost was settled. The prepaid wallet is only touched
+ * by the 'balance' method; the others owe/settle with the owner directly:
+ *   - 'etransfer' → wallet unchanged; logs a wallet-neutral 'payment' (owed to owner)
+ *   - 'comp'      → wallet unchanged; logs a wallet-neutral 'comp' (off the payout)
+ *   - 'balance'   → draws −cost from prepaid credit (may go negative; caller warns)
+ *   - null        → unpaid; wallet unchanged, the player owes the cost
+ * Switching into 'balance' draws the cost; switching out of it refunds the cost.
  */
 export async function setPlayerSettlement(
   sessionId: string,
@@ -529,31 +558,34 @@ export async function setPlayerSettlement(
 
       let before = (playerSnap.data()?.balance as number) ?? 0;
       const initial = before;
-      let logged = false;
-      const log = (delta: number, reason: string, note: string) => {
+      const logWallet = (delta: number, reason: string, note: string) => {
         tx.set(doc(refs.balanceLedger), {
           playerId, sessionId, delta,
           balanceBefore: before, balanceAfter: before + delta,
           reason, note, createdAt: serverTimestamp(),
         });
         before += delta;
-        logged = true;
+      };
+      const logPayout = (delta: number, reason: string, note: string) => {
+        tx.set(doc(refs.balanceLedger), {
+          playerId, sessionId, delta,
+          balanceBefore: before, balanceAfter: before,
+          reason, note, createdAt: serverTimestamp(),
+        });
       };
 
-      // 'balance' draws the cost from prepaid credit and may leave the player negative
-      // (the UI warns before selecting it); it never affects the owner payout.
+      // Reverse the old payout signal, then record the new one (wallet-neutral).
+      if (currentVia === 'etransfer') logPayout(-cost, 'payment', 'Reversed e-Transfer payment');
+      else if (currentVia === 'comp')  logPayout(-cost, 'comp', 'Reversed comp');
+      if (method === 'etransfer') logPayout(cost, 'payment', 'Paid by e-Transfer');
+      else if (method === 'comp')  logPayout(cost, 'comp', 'Comped — player paid owner directly');
 
-      // Reverse the current method's settlement credit…
-      if (currentVia === 'etransfer') log(-cost, 'payment', 'Reversed e-Transfer payment');
-      else if (currentVia === 'comp')  log(-cost, 'comp', 'Reversed comp');
-      // …then apply the new method's settlement credit.
-      if (method === 'etransfer') log(cost, 'payment', 'Paid by e-Transfer');
-      else if (method === 'comp')  log(cost, 'comp', 'Comped — player paid owner directly');
-      else if (!logged) {
-        // Balance/unpaid don't move the balance (the session debit already stands),
-        // so record a zero-delta entry to keep the change in the balance history.
-        log(0, 'settlement', method === 'balance' ? 'Settled from prepaid balance' : 'Marked unpaid');
-      }
+      // The prepaid wallet only moves for the 'balance' method.
+      if (currentVia === 'balance') logWallet(cost, 'settlement', 'Refunded prepaid balance');
+      if (method === 'balance')     logWallet(-cost, 'settlement', 'Settled from prepaid balance');
+
+      // Session debt is owed only while unsettled (paidVia === null).
+      const owedDelta = (method === null ? cost : 0) - (currentVia === null ? cost : 0);
 
       const updatedPlayers = players.map(p =>
         p.id === playerId
@@ -568,7 +600,10 @@ export async function setPlayerSettlement(
       tx.update(sessionRef, { players: updatedPlayers });
 
       const netDelta = before - initial;
-      if (netDelta !== 0) tx.update(playerRef, { balance: increment(netDelta) });
+      const playerUpdate: Record<string, ReturnType<typeof increment>> = {};
+      if (netDelta !== 0)  playerUpdate.balance = increment(netDelta);
+      if (owedDelta !== 0) playerUpdate.owed = increment(owedDelta);
+      if (Object.keys(playerUpdate).length) tx.update(playerRef, playerUpdate);
     });
   });
 }
@@ -643,21 +678,41 @@ export async function deleteSession(sessionId: string): Promise<void> {
       players.forEach((p, i) => {
         const snap = playerSnaps[i];
         if (!snap.exists()) return;
+        const via: PaidVia = p.paidVia ?? (p.comped ? 'comp' : p.paid ? 'etransfer' : null);
         const before = (snap.data()?.balance as number) ?? 0;
+
+        if (via === 'etransfer' || via === 'comp') {
+          tx.set(doc(refs.balanceLedger), {
+            playerId:      p.id,
+            sessionId,
+            delta:         -p.cost,
+            balanceBefore: before,
+            balanceAfter:  before,
+            reason:        via === 'etransfer' ? 'payment' : 'comp',
+            note:          'Reversed — session deleted',
+            createdAt:     serverTimestamp(),
+          });
+        }
+
+        const walletRefund = via === 'balance' ? p.cost : 0;
+        const owedForSession = via === null ? p.cost : 0;
         tx.update(snap.ref, {
-          balance:      increment(p.cost),
           sessionCount: increment(-1),
+          ...(walletRefund !== 0 ? { balance: increment(walletRefund) } : {}),
+          ...(owedForSession !== 0 ? { owed: increment(-owedForSession) } : {}),
         });
-        tx.set(doc(refs.balanceLedger), {
-          playerId:      p.id,
-          sessionId,
-          delta:         p.cost,
-          balanceBefore: before,
-          balanceAfter:  before + p.cost,
-          reason:        'session-deleted',
-          note:          'Session deleted',
-          createdAt:     serverTimestamp(),
-        });
+        if (walletRefund !== 0) {
+          tx.set(doc(refs.balanceLedger), {
+            playerId:      p.id,
+            sessionId,
+            delta:         walletRefund,
+            balanceBefore: before,
+            balanceAfter:  before + walletRefund,
+            reason:        'session-deleted',
+            note:          'Session deleted',
+            createdAt:     serverTimestamp(),
+          });
+        }
       });
 
       // Archive a copy, then delete the original.

--- a/ui/src/services/firebase/sessions.ts
+++ b/ui/src/services/firebase/sessions.ts
@@ -318,6 +318,19 @@ export async function editSession(
           throw new Error(`Court credit ${id}: insufficient hours for edit`);
 
         tx.update(snap.ref, { remainingHours: d.remainingHours - delta });
+
+        // Log adjustment transaction
+        const cost = delta * (d.costPerHour ?? 0);
+        tx.set(doc(refs.transactions), {
+          resourceType: 'court',
+          batchId:      id,
+          hoursUsed:    delta,
+          cost,
+          sessionId,
+          date:        Timestamp.fromDate(updatedData.date),
+          createdAt:   serverTimestamp(),
+          description: 'Session Edit Adjustment',
+        });
       });
 
       // ── Player balance + membership deltas ─────────────────────────────────────────

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -10,6 +10,7 @@ export interface Player {
   lastNameLower: string | null;
   email: string | null;
   balance: number;
+  owed: number; // unsettled session debt (sum of costs for sessions the player hasn't settled)
   description: string;
   sessionCount: number; // replaces attendedSessionIds[] — cheap increment, no unbounded array
   createdAt: Timestamp;


### PR DESCRIPTION
- Only the 'balance' settlement draws the prepaid wallet; undoing it now refunds the wallet. e-Transfer/comp stay wallet-neutral but still feed the owner payout; unpaid no longer debits the wallet.
- Add an 'owed' counter on the player doc for unsettled session debt, maintained across add/edit/settle/delete. No backfill (missing = 0).
- Surface Balance vs Owed on the Players tab, home dashboard, and member self-view; hide payment/comp entries from the wallet Balance History.
- Fix editSession wiping settlement state (players reset to unpaid) by preserving paid/paidVia/comped/highlighted, and re-price the payout when a settled player's cost changes.