### PR TITLE
Add paying a player's dues from another player's balance

### DIFF
--- a/ui/public/favicon.svg
+++ b/ui/public/favicon.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="14" fill="#0d6efd"/>
+  <!-- feather skirt -->
+  <path d="M19 15 L45 15 L38 45 L26 45 Z" fill="#ffffff"/>
+  <!-- feather dividers -->
+  <g stroke="#0d6efd" stroke-width="1.6" stroke-linecap="round" fill="none">
+    <path d="M32 15 L32 45"/>
+    <path d="M25 15 L28.5 45"/>
+    <path d="M39 15 L35.5 45"/>
+    <path d="M26.5 39 L37.5 39"/>
+  </g>
+  <!-- cork base -->
+  <path d="M26 45 L38 45 L37 52 a5 6 0 0 1 -10 0 Z" fill="#f4c99a" stroke="#dca971" stroke-width="1.2"/>
+</svg>

--- a/ui/public/index.html
+++ b/ui/public/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
+    <link rel="icon" type="image/svg+xml" href="%PUBLIC_URL%/favicon.svg" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />

--- a/ui/src/Pages/PlayersPage.tsx
+++ b/ui/src/Pages/PlayersPage.tsx
@@ -14,7 +14,7 @@ import { useSearchParams, Link } from 'react-router-dom';
 import { getMonthYear } from '../utils/dateUtils';
 import AddPlayerModal from '../components/AddPlayerModal';
 import ConfirmDialog from '../components/ConfirmDialog';
-import { db, refs, setPlayerSettlement } from '../services/firebase';
+import { db, refs, setPlayerSettlement, setPlayerPaidBy } from '../services/firebase';
 import { addPlayer, updatePlayerProfile } from '../services/firebase/players';
 import {
   collection, query, where, getDocs, orderBy,
@@ -194,6 +194,18 @@ console.log("selectedPlayer ==> ", selectedPlayer);
     }
   };
 
+  const handleSetPaidBy = async (sessionId: string, payerId: string) => {
+    if (!selectedPlayerId) return;
+    setSessionsError('');
+    try {
+      await setPlayerPaidBy(sessionId, selectedPlayerId, payerId);
+      await fetchAttendedSessions({ silent: true });
+      await fetchLedger(selectedPlayerId, { silent: true });
+    } catch (err) {
+      setSessionsError(err instanceof Error ? err.message : 'Failed to update settlement.');
+    }
+  };
+
   // Balance adjustment
   const handleBalanceSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -313,7 +325,7 @@ console.log("selectedPlayer ==> ", selectedPlayer);
   const walletLedger = ledger.filter(e => e.reason !== 'payment' && e.reason !== 'comp');
 
   return (
-    <Container fluid className="mt-4">
+    <Container fluid className="mt-4 pb-4">
       <Row className="mb-3">
         <Col className="text-end">
           <Button variant="success" onClick={() => setShowAddModal(true)}>+ Add New Player</Button>
@@ -599,7 +611,7 @@ console.log("selectedPlayer ==> ", selectedPlayer);
                     <p className="text-muted small">No sessions attended this month.</p>
                   )}
                   {!isLoadingSessions && attendedSessions.length > 0 && (
-                    <ListGroup variant="flush" style={{ maxHeight: 440, overflowY: 'auto' }}>
+                    <ListGroup variant="flush" style={{ maxHeight: 'calc(100vh - 320px)', overflowY: 'auto' }}>
                       {attendedSessions.map(s => {
                         const playerInSession = s.players.find(p => p.id === selectedPlayerId);
                         const sessionDate =
@@ -646,17 +658,64 @@ console.log("selectedPlayer ==> ", selectedPlayer);
                                     }
                                     handleSetSettlement(s.id, method);
                                   };
+                                  // Cover the selected player's dues from another player's balance.
+                                  const otherPlayers = playersList
+                                    .filter(pp => pp.id !== selectedPlayerId)
+                                    .map(pp => ({ id: pp.id, name: formatPlayerName(pp), balance: pp.balance }));
+                                  const currentPayer = via === 'transfer' && playerInSession.paidBy
+                                    ? playersList.find(pp => pp.id === playerInSession.paidBy)
+                                    : undefined;
+                                  const payerName = currentPayer ? formatPlayerName(currentPayer) : undefined;
+                                  const pickPaidBy = (payerId: string) => {
+                                    if (payerId === playerInSession.paidBy) return;
+                                    const opt = otherPlayers.find(o => o.id === payerId);
+                                    if (opt && opt.balance < playerInSession.cost) {
+                                      const ok = window.confirm(
+                                        `${opt.name} has $${opt.balance.toFixed(2)} — covering $${playerInSession.cost.toFixed(2)} ` +
+                                        `will leave them at $${(opt.balance - playerInSession.cost).toFixed(2)} (negative). Continue?`
+                                      );
+                                      if (!ok) return;
+                                    }
+                                    handleSetPaidBy(s.id, payerId);
+                                  };
                                   return (
                                     <ButtonGroup size="sm" className="mt-1">
                                       {settleOptions.map(o => (
-                                        <Button
-                                          key={o.label}
-                                          variant={via === o.method ? o.activeVariant : 'outline-secondary'}
-                                          style={{ fontSize: 11, padding: '1px 8px' }}
-                                          onClick={() => pick(o.method)}
-                                        >
-                                          {o.label}
-                                        </Button>
+                                        <React.Fragment key={o.label}>
+                                          <Button
+                                            variant={via === o.method ? o.activeVariant : 'outline-secondary'}
+                                            style={{ fontSize: 11, padding: '1px 8px' }}
+                                            onClick={() => pick(o.method)}
+                                          >
+                                            {o.label}
+                                          </Button>
+                                          {o.method === null && otherPlayers.length > 0 && (
+                                            <Dropdown as={ButtonGroup} align="end">
+                                              <Dropdown.Toggle
+                                                variant={via === 'transfer' ? 'primary' : 'outline-secondary'}
+                                                style={{ fontSize: 11, padding: '1px 8px', maxWidth: 130 }}
+                                                className="text-truncate"
+                                                title="Pay these dues from another player's balance"
+                                              >
+                                                {via === 'transfer' && payerName ? payerName : 'Paid by'}
+                                              </Dropdown.Toggle>
+                                              <Dropdown.Menu style={{ maxHeight: 320, overflowY: 'auto' }}>
+                                                <Dropdown.Header>Pay from another's balance</Dropdown.Header>
+                                                {otherPlayers.map(op => (
+                                                  <Dropdown.Item
+                                                    key={op.id}
+                                                    active={via === 'transfer' && playerInSession.paidBy === op.id}
+                                                    onClick={() => pickPaidBy(op.id)}
+                                                    className="d-flex justify-content-between align-items-center gap-3"
+                                                  >
+                                                    <span>{op.name}</span>
+                                                    <span className="text-muted small">${op.balance.toFixed(2)}</span>
+                                                  </Dropdown.Item>
+                                                ))}
+                                              </Dropdown.Menu>
+                                            </Dropdown>
+                                          )}
+                                        </React.Fragment>
                                       ))}
                                     </ButtonGroup>
                                   );

--- a/ui/src/components/AppNavBar.tsx
+++ b/ui/src/components/AppNavBar.tsx
@@ -24,7 +24,17 @@ export default function AppNavbar() {
     return (
         <Navbar bg="primary" variant="dark" expand="lg" sticky="top" style={{ marginBottom: 20, paddingBottom: 10 }}>
             <Container>
-                <Navbar.Brand as={Link} to="/">
+                <Navbar.Brand as={Link} to="/" className="d-flex align-items-center gap-2">
+                    <svg width="22" height="22" viewBox="0 0 64 64" aria-hidden="true">
+                        <path d="M19 15 L45 15 L38 45 L26 45 Z" fill="#ffffff" />
+                        <g stroke="#0d6efd" strokeWidth="1.6" strokeLinecap="round" fill="none">
+                            <path d="M32 15 L32 45" />
+                            <path d="M25 15 L28.5 45" />
+                            <path d="M39 15 L35.5 45" />
+                            <path d="M26.5 39 L37.5 39" />
+                        </g>
+                        <path d="M26 45 L38 45 L37 52 a5 6 0 0 1 -10 0 Z" fill="#f4c99a" stroke="#dca971" strokeWidth="1.2" />
+                    </svg>
                     Badminton Ledger
                 </Navbar.Brand>
                 <Navbar.Toggle aria-controls="main-nav" />

--- a/ui/src/components/Calander/steps/ExistingSessionView.tsx
+++ b/ui/src/components/Calander/steps/ExistingSessionView.tsx
@@ -1,11 +1,11 @@
 import React, { useMemo, useState } from 'react';
-import { Alert, Badge, Button, ButtonGroup, Col, Form, ListGroup, Row } from 'react-bootstrap';
+import { Alert, Badge, Button, ButtonGroup, Col, Dropdown, Form, ListGroup, Row } from 'react-bootstrap';
 import { Link } from 'react-router-dom';
 import { format } from 'date-fns';
 import { useAppSelector } from 'hooks';
-import { selectPlayerById } from '../../../features/players/playersSlice';
+import { selectPlayerById, selectAllPlayers } from '../../../features/players/playersSlice';
 import { selectDisabledTabs, selectIsClubAdmin } from '../../../features/club/clubSlice';
-import { setPlayerSettlement, togglePlayerHighlightStatus } from '../../../services/firebase';
+import { setPlayerSettlement, setPlayerPaidBy } from '../../../services/firebase';
 import type { PaidVia, Session, SessionPlayer } from 'types';
 import type { RootState } from '../../../store';
 
@@ -20,6 +20,15 @@ export default function ExistingSessionView({ session, onSessionUpdate, onEdit, 
   const isAdmin = useAppSelector(selectIsClubAdmin);
   const disabledTabs = useAppSelector(selectDisabledTabs);
   const birdiesEnabled = !disabledTabs.includes('birdies');
+  const allPlayers = useAppSelector(selectAllPlayers);
+  const payerOptions = useMemo(
+    () => allPlayers.map(p => ({
+      id:      p.id,
+      name:    [p.firstName, p.lastName].filter(Boolean).join(' '),
+      balance: p.balance,
+    })),
+    [allPlayers],
+  );
   const [confirmingDelete, setConfirmingDelete] = useState(false);
   const [deleteText, setDeleteText] = useState('');
   const [deleting, setDeleting] = useState(false);
@@ -67,8 +76,9 @@ export default function ExistingSessionView({ session, onSessionUpdate, onEdit, 
             key={player.id}
             player={player}
             isAdmin={isAdmin}
+            payerOptions={payerOptions}
             onSetSettlement={(method) => refresh(() => setPlayerSettlement(session.id, player.id, method))}
-            onToggleHighlight={() => refresh(() => togglePlayerHighlightStatus(session.id, player.id))}
+            onSetPaidBy={(payerId) => refresh(() => setPlayerPaidBy(session.id, player.id, payerId))}
           />
         ))}
       </ListGroup>
@@ -133,12 +143,13 @@ export default function ExistingSessionView({ session, onSessionUpdate, onEdit, 
 }
 
 function PlayerRow({
-  player, isAdmin, onSetSettlement, onToggleHighlight,
+  player, isAdmin, payerOptions, onSetSettlement, onSetPaidBy,
 }: {
   player:            SessionPlayer;
   isAdmin:           boolean;
+  payerOptions:      { id: string; name: string; balance: number }[];
   onSetSettlement:   (method: PaidVia) => void;
-  onToggleHighlight: () => void;
+  onSetPaidBy:       (payerId: string) => void;
 }) {
   const stored = useAppSelector((s: RootState) => selectPlayerById(s, player.id));
   const name   = stored
@@ -147,6 +158,14 @@ function PlayerRow({
 
   const currentVia: PaidVia =
     player.paidVia ?? (player.comped ? 'comp' : player.paid ? 'etransfer' : null);
+
+  // Resolve the payer's name when this player's dues were covered from another's balance.
+  const payer = useAppSelector((s: RootState) =>
+    player.paidBy ? selectPlayerById(s, player.paidBy) : undefined
+  );
+  const payerName = payer
+    ? [payer.firstName, payer.lastName].filter(Boolean).join(' ')
+    : player.paidBy;
 
   // Choosing 'balance' draws the session cost from prepaid credit, which can leave the
   // player negative. Compute the resulting balance to warn.
@@ -164,21 +183,39 @@ function PlayerRow({
     onSetSettlement(method);
   };
 
+  // Cover this player's dues from another player's prepaid balance ('transfer').
+  const handlePaidBy = (payerId: string) => {
+    if (!payerId || payerId === player.paidBy) return;
+    const opt = payerOptions.find(o => o.id === payerId);
+    if (opt && opt.balance < player.cost) {
+      const ok = window.confirm(
+        `${opt.name} has $${opt.balance.toFixed(2)} — covering $${player.cost.toFixed(2)} ` +
+        `will leave them at $${(opt.balance - player.cost).toFixed(2)} (negative). Continue?`
+      );
+      if (!ok) return;
+    }
+    onSetPaidBy(payerId);
+  };
+
   // Clearly marks how the session was settled (shown to members).
   const settlement = player.comped
     ? { label: 'Comp', bg: 'info' }
-    : player.paid
-      ? (player.paidVia === 'balance'
-          ? { label: 'Balance', bg: 'primary' }
-          : { label: 'e-Transfer', bg: 'success' })
-      : { label: 'Unpaid', bg: 'danger' };
+    : currentVia === 'transfer'
+      ? { label: payerName ? `Paid by ${payerName}` : 'Covered', bg: 'primary' }
+      : player.paid
+        ? (player.paidVia === 'balance'
+            ? { label: 'Balance', bg: 'primary' }
+            : { label: 'e-Transfer', bg: 'success' })
+        : { label: 'Unpaid', bg: 'danger' };
 
   const options: { method: PaidVia; label: string; activeVariant: string }[] = [
-    { method: null,        label: 'Unpaid',  activeVariant: 'danger'  },
-    { method: 'comp',      label: 'Comp',    activeVariant: 'info'    },
-    { method: 'balance',   label: 'Balance', activeVariant: 'primary' },
-    { method: 'etransfer', label: 'e-Trans', activeVariant: 'success' },
+    { method: null,        label: 'Unpaid',     activeVariant: 'danger'  },
+    { method: 'comp',      label: 'Comp',       activeVariant: 'info'    },
+    { method: 'balance',   label: 'Balance',    activeVariant: 'primary' },
+    { method: 'etransfer', label: 'e-Transfer', activeVariant: 'success' },
   ];
+
+  const otherPlayers = payerOptions.filter(o => o.id !== player.id);
 
   return (
     <ListGroup.Item
@@ -195,25 +232,45 @@ function PlayerRow({
       <div className="d-flex align-items-center gap-2">
         <span className={player.paid ? 'text-muted' : ''}>${player.cost.toFixed(2)}</span>
         {isAdmin ? (
-          <>
-            <Button size="sm" variant={player.highlighted ? 'warning' : 'outline-secondary'} onClick={onToggleHighlight}>
-              {player.highlighted ? '★' : '☆'}
-            </Button>
-            <ButtonGroup size="sm">
-              {options.map(o => {
-                const active = currentVia === o.method;
-                return (
+          <ButtonGroup size="sm">
+              {options.map(o => (
+                <React.Fragment key={o.label}>
                   <Button
-                    key={o.label}
-                    variant={active ? o.activeVariant : 'outline-secondary'}
+                    variant={currentVia === o.method ? o.activeVariant : 'outline-secondary'}
                     onClick={() => handleSelect(o.method)}
                   >
                     {o.label}
                   </Button>
-                );
-              })}
+                  {o.method === null && otherPlayers.length > 0 && (
+                    <Dropdown as={ButtonGroup} align="end">
+                      <Dropdown.Toggle
+                        size="sm"
+                        variant={currentVia === 'transfer' ? 'primary' : 'outline-secondary'}
+                        title="Pay this player's dues from another player's balance"
+                        className="text-truncate"
+                        style={{ maxWidth: 150 }}
+                      >
+                        {currentVia === 'transfer' && payerName ? payerName : 'Paid by'}
+                      </Dropdown.Toggle>
+                      <Dropdown.Menu style={{ maxHeight: 320, overflowY: 'auto' }}>
+                        <Dropdown.Header>Pay from another's balance</Dropdown.Header>
+                        {otherPlayers.map(op => (
+                          <Dropdown.Item
+                            key={op.id}
+                            active={currentVia === 'transfer' && player.paidBy === op.id}
+                            onClick={() => handlePaidBy(op.id)}
+                            className="d-flex justify-content-between align-items-center gap-3"
+                          >
+                            <span>{op.name}</span>
+                            <span className="text-muted small">${op.balance.toFixed(2)}</span>
+                          </Dropdown.Item>
+                        ))}
+                      </Dropdown.Menu>
+                    </Dropdown>
+                  )}
+                </React.Fragment>
+              ))}
             </ButtonGroup>
-          </>
         ) : (
           <Badge bg={settlement.bg} style={{ fontSize: 10, minWidth: 72 }}>
             {settlement.label}

--- a/ui/src/components/Calander/steps/ExistingSessionView.tsx
+++ b/ui/src/components/Calander/steps/ExistingSessionView.tsx
@@ -217,6 +217,13 @@ function PlayerRow({
 
   const otherPlayers = payerOptions.filter(o => o.id !== player.id);
 
+  // Search box for the "Paid by" dropdown — filters otherPlayers by name.
+  const [payerSearch, setPayerSearch] = useState('');
+  const filteredPayers = useMemo(
+    () => otherPlayers.filter(o => o.name.toLowerCase().includes(payerSearch.trim().toLowerCase())),
+    [otherPlayers, payerSearch]
+  );
+
   return (
     <ListGroup.Item
       className="d-flex justify-content-between align-items-center"
@@ -242,7 +249,11 @@ function PlayerRow({
                     {o.label}
                   </Button>
                   {o.method === null && otherPlayers.length > 0 && (
-                    <Dropdown as={ButtonGroup} align="end">
+                    <Dropdown
+                      as={ButtonGroup}
+                      align="end"
+                      onToggle={(isOpen) => { if (!isOpen) setPayerSearch(''); }}
+                    >
                       <Dropdown.Toggle
                         size="sm"
                         variant={currentVia === 'transfer' ? 'primary' : 'outline-secondary'}
@@ -252,19 +263,36 @@ function PlayerRow({
                       >
                         {currentVia === 'transfer' && payerName ? payerName : 'Paid by'}
                       </Dropdown.Toggle>
-                      <Dropdown.Menu style={{ maxHeight: 320, overflowY: 'auto' }}>
+                      <Dropdown.Menu style={{ maxHeight: 360, overflowY: 'auto' }}>
                         <Dropdown.Header>Pay from another's balance</Dropdown.Header>
-                        {otherPlayers.map(op => (
-                          <Dropdown.Item
-                            key={op.id}
-                            active={currentVia === 'transfer' && player.paidBy === op.id}
-                            onClick={() => handlePaidBy(op.id)}
-                            className="d-flex justify-content-between align-items-center gap-3"
-                          >
-                            <span>{op.name}</span>
-                            <span className="text-muted small">${op.balance.toFixed(2)}</span>
-                          </Dropdown.Item>
-                        ))}
+                        <div className="px-2 pb-2">
+                          <Form.Control
+                            size="sm"
+                            autoFocus
+                            placeholder="Search players…"
+                            value={payerSearch}
+                            onChange={(e) => setPayerSearch(e.target.value)}
+                            onClick={(e) => e.stopPropagation()}
+                            onKeyDown={(e) => e.stopPropagation()}
+                          />
+                        </div>
+                        {filteredPayers.length === 0 ? (
+                          <Dropdown.ItemText className="text-muted small px-3">
+                            No players found.
+                          </Dropdown.ItemText>
+                        ) : (
+                          filteredPayers.map(op => (
+                            <Dropdown.Item
+                              key={op.id}
+                              active={currentVia === 'transfer' && player.paidBy === op.id}
+                              onClick={() => handlePaidBy(op.id)}
+                              className="d-flex justify-content-between align-items-center gap-3"
+                            >
+                              <span>{op.name}</span>
+                              <span className="text-muted small">${op.balance.toFixed(2)}</span>
+                            </Dropdown.Item>
+                          ))
+                        )}
                       </Dropdown.Menu>
                     </Dropdown>
                   )}

--- a/ui/src/components/Calander/steps/SessionDetailsStep.tsx
+++ b/ui/src/components/Calander/steps/SessionDetailsStep.tsx
@@ -142,6 +142,7 @@ export default function SessionDetailsStep({ session, onSave, onCancel }: Props)
         cost:        parseFloat((perUnit * p.percentage).toFixed(2)),
         paid:        existing?.paid ?? false,
         paidVia:     existing?.paidVia ?? null,
+        paidBy:      existing?.paidBy ?? null,
         comped:      existing?.comped ?? false,
         highlighted: existing?.highlighted ?? false,
       };

--- a/ui/src/services/firebase/sessions.ts
+++ b/ui/src/services/firebase/sessions.ts
@@ -82,8 +82,15 @@ export async function addSession(data: NewSessionData): Promise<string> {
     const sessionRef = doc(refs.sessions); // generate ID before transaction
 
     await runTransaction(db, async (tx) => {
+      // Players whose prepaid balance covers *another* player's cost via a 'transfer'
+      // settlement — their docs must be read/written even if they aren't participants.
+      const payerIds = data.players
+        .filter(p => p.paidVia === 'transfer' && p.paidBy)
+        .map(p => p.paidBy as string);
+      const balanceIds = [...new Set([...data.players.map(p => p.id), ...payerIds])];
+
       // ── 1. Read all affected documents first (Firestore rule: reads before writes) ──
-      const [birdieDocs, courtDocs, playerDocs] = await Promise.all([
+      const [birdieDocs, courtDocs, balanceDocs] = await Promise.all([
         Promise.all(
           data.birdieUsage.map(u => tx.get(doc(refs.birdieInventory, u.id)))
         ),
@@ -91,9 +98,11 @@ export async function addSession(data: NewSessionData): Promise<string> {
           data.courtCreditUsage.map(u => tx.get(doc(refs.courtCredits, u.id)))
         ),
         Promise.all(
-          data.players.map(p => tx.get(doc(refs.players, p.id)))
+          balanceIds.map(id => tx.get(doc(refs.players, id)))
         ),
       ]);
+      const playerSnapMap = new Map(balanceIds.map((id, i) => [id, balanceDocs[i]]));
+      const playerDocs = data.players.map(p => playerSnapMap.get(p.id)!);
 
       // ── 2. Validate before any writes ────────────────────────────────────────────
       data.birdieUsage.forEach((usage, i) => {
@@ -177,27 +186,63 @@ export async function addSession(data: NewSessionData): Promise<string> {
       });
 
       // ── 6. Update player balances + session counts ────────────────────────────────
+      // Aggregate every prepaid-balance draw: a player settling their own cost via
+      // 'balance', plus any player covering *others* via a 'transfer'. Both reduce the
+      // paying player's balance, so they're summed per payer for a single balance write.
+      const sessionDate = data.date.toLocaleDateString();
+      const walletDraw = new Map<string, { amount: number; note: string }[]>();
+      const addDraw = (id: string, amount: number, note: string) => {
+        const list = walletDraw.get(id) ?? [];
+        list.push({ amount, note });
+        walletDraw.set(id, list);
+      };
+      resolvedPlayers.forEach(player => {
+        if (player.paidVia === 'balance') {
+          addDraw(player.id, player.cost, `Session on ${sessionDate}`);
+        } else if (player.paidVia === 'transfer' && player.paidBy) {
+          addDraw(player.paidBy, player.cost, `Covered a player's dues — session on ${sessionDate}`);
+        }
+      });
+
+      // Validate every payer exists and can cover what's drawn from their balance.
+      walletDraw.forEach((entries, id) => {
+        const snap = playerSnapMap.get(id);
+        if (!snap?.exists()) throw new Error(`Paying player ${id} not found`);
+        const before = (snap.data()?.balance as number) ?? 0;
+        const total  = entries.reduce((s, e) => s + e.amount, 0);
+        if (total > before)
+          throw new Error(`Player ${id} has $${before.toFixed(2)} but $${total.toFixed(2)} was drawn from their balance`);
+      });
+
+      // Bump attendance + record session debt for participants who still owe.
       resolvedPlayers.forEach((player, i) => {
-        const drawsWallet = player.paidVia === 'balance';
         const owesForSession = !player.paid && !player.comped;
-        const before = (playerDocs[i].data()?.balance as number) ?? 0;
         tx.update(playerDocs[i].ref, {
           sessionCount: increment(1),
-          ...(drawsWallet ? { balance: increment(-player.cost) } : {}),
           ...(owesForSession ? { owed: increment(player.cost) } : {}),
         });
-        if (drawsWallet) {
+      });
+
+      // Apply each payer's aggregated balance draw once, logging a ledger entry per draw.
+      walletDraw.forEach((entries, id) => {
+        const snap  = playerSnapMap.get(id)!;
+        const total = entries.reduce((s, e) => s + e.amount, 0);
+        tx.update(snap.ref, { balance: increment(-total) });
+
+        let before = (snap.data()?.balance as number) ?? 0;
+        entries.forEach(entry => {
           tx.set(doc(refs.balanceLedger), {
-            playerId:      player.id,
+            playerId:      id,
             sessionId:     sessionRef.id,
-            delta:         -player.cost,
+            delta:         -entry.amount,
             balanceBefore: before,
-            balanceAfter:  before - player.cost,
+            balanceAfter:  before - entry.amount,
             reason:        'session',
-            note:          `Session on ${data.date.toLocaleDateString()}`,
+            note:          entry.note,
             createdAt:     serverTimestamp(),
           });
-        }
+          before -= entry.amount;
+        });
       });
     });
 
@@ -241,6 +286,10 @@ export async function editSession(
       const allPlayerIds = new Set([
         ...original.players.map(p => p.id),
         ...updatedData.players.map(p => p.id),
+        // Players covering others' dues from their balance ('transfer') must be
+        // read/written too, even when they aren't participants themselves.
+        ...original.players.filter(p => p.paidVia === 'transfer' && p.paidBy).map(p => p.paidBy as string),
+        ...updatedData.players.filter(p => p.paidVia === 'transfer' && p.paidBy).map(p => p.paidBy as string),
       ]);
 
       const [birdieSnaps, courtSnaps, playerSnaps] = await Promise.all([
@@ -261,6 +310,31 @@ export async function editSession(
         return coveredByBalance && !player.paid && !player.comped
           ? { ...player, paid: true, paidVia: 'balance' as const }
           : player;
+      });
+
+      // Aggregate prepaid-balance draws (own 'balance' + 'transfer' coverage of others)
+      // per paying player, for both the original and updated session. Deltas below are
+      // applied to whoever's balance was drawn — which, for a transfer, is the payer.
+      const walletDrawOf = (players: SessionPlayer[]): Map<string, number> => {
+        const m = new Map<string, number>();
+        const add = (id: string, amt: number) => m.set(id, (m.get(id) ?? 0) + amt);
+        players.forEach(p => {
+          const via = p.paidVia ?? (p.comped ? 'comp' : p.paid ? 'etransfer' : null);
+          if (via === 'balance') add(p.id, p.cost);
+          else if (via === 'transfer' && p.paidBy) add(p.paidBy, p.cost);
+        });
+        return m;
+      };
+      const oldDraw = walletDrawOf(original.players);
+      const newDraw = walletDrawOf(resolvedPlayers);
+
+      // A payer's balance, after refunding the old draw, must cover the new draw.
+      newDraw.forEach((amount, id) => {
+        const snap = playerMap.get(id);
+        if (!snap?.exists()) throw new Error(`Paying player ${id} not found`);
+        const available = ((snap.data()?.balance as number) ?? 0) + (oldDraw.get(id) ?? 0);
+        if (amount > available)
+          throw new Error(`Player ${id} has $${available.toFixed(2)} available but $${amount.toFixed(2)} was drawn from their balance`);
       });
 
       // ── Write phase: update session ────────────────────────────────────────────────
@@ -347,7 +421,9 @@ export async function editSession(
         const oldCost = oldPlayer?.cost ?? 0;
         const newCost = newPlayer?.cost ?? 0;
 
-        const walletDelta  = (oldVia === 'balance' ? oldCost : 0) - (newVia === 'balance' ? newCost : 0);
+        // Balance draws are keyed by the *paying* player (own 'balance' or, for a
+        // 'transfer', the payer), so read the delta straight from the draw maps.
+        const walletDelta  = (oldDraw.get(id) ?? 0) - (newDraw.get(id) ?? 0);
         const owedDelta    = (newPlayer && newVia === null ? newCost : 0) - (oldPlayer && oldVia === null ? oldCost : 0);
         const paymentDelta = (newVia === 'etransfer' ? newCost : 0) - (oldVia === 'etransfer' ? oldCost : 0);
         const compDelta    = (newVia === 'comp' ? newCost : 0) - (oldVia === 'comp' ? oldCost : 0);
@@ -552,13 +628,11 @@ export async function setPlayerSettlement(
     const playerRef  = doc(refs.players, playerId);
 
     await runTransaction(db, async (tx) => {
-      const [sessionSnap, playerSnap] = await Promise.all([
-        tx.get(sessionRef),
-        tx.get(playerRef),
-      ]);
+      if (method === 'transfer')
+        throw new Error("Use setPlayerPaidBy to settle a player from another player's balance");
 
+      const sessionSnap = await tx.get(sessionRef);
       if (!sessionSnap.exists()) throw new Error(`Session ${sessionId} not found`);
-      if (!playerSnap.exists()) throw new Error(`Player ${playerId} not found`);
 
       const players = sessionSnap.data().players as SessionPlayer[];
       const target  = players.find(p => p.id === playerId);
@@ -568,6 +642,14 @@ export async function setPlayerSettlement(
       const currentVia: PaidVia =
         target.paidVia ?? (target.comped ? 'comp' : target.paid ? 'etransfer' : null);
       if (currentVia === method) return; // no change
+
+      // Leaving a 'transfer' refunds the *payer* (not the payee), so read them too.
+      const oldPayerId = currentVia === 'transfer' ? (target.paidBy ?? null) : null;
+      const [playerSnap, oldPayerSnap] = await Promise.all([
+        tx.get(playerRef),
+        oldPayerId ? tx.get(doc(refs.players, oldPayerId)) : Promise.resolve(null),
+      ]);
+      if (!playerSnap.exists()) throw new Error(`Player ${playerId} not found`);
 
       let before = (playerSnap.data()?.balance as number) ?? 0;
       const initial = before;
@@ -607,6 +689,7 @@ export async function setPlayerSettlement(
               paid:    method === 'etransfer' || method === 'balance',
               comped:  method === 'comp',
               paidVia: method,
+              paidBy:  null,
             }
           : p
       );
@@ -617,6 +700,139 @@ export async function setPlayerSettlement(
       if (netDelta !== 0)  playerUpdate.balance = increment(netDelta);
       if (owedDelta !== 0) playerUpdate.owed = increment(owedDelta);
       if (Object.keys(playerUpdate).length) tx.update(playerRef, playerUpdate);
+
+      // If this player had been covered from someone else's balance, refund that payer.
+      if (oldPayerId && oldPayerSnap?.exists()) {
+        const payerBefore = (oldPayerSnap.data()?.balance as number) ?? 0;
+        tx.update(oldPayerSnap.ref, { balance: increment(cost) });
+        tx.set(doc(refs.balanceLedger), {
+          playerId:      oldPayerId,
+          sessionId,
+          delta:         cost,
+          balanceBefore: payerBefore,
+          balanceAfter:  payerBefore + cost,
+          reason:        'settlement',
+          note:          'Refunded — no longer covering another player',
+          createdAt:     serverTimestamp(),
+        });
+      }
+    });
+  });
+}
+
+/**
+ * Settles a player's session cost from *another* player's prepaid balance.
+ * The paying player's balance is drawn (may go negative; caller warns) and the payee is
+ * marked paid via 'transfer'. Any prior settlement on the payee is reversed first —
+ * including refunding a previous payer when the payer is being changed.
+ */
+export async function setPlayerPaidBy(
+  sessionId: string,
+  playerId: string,
+  payerId: string,
+): Promise<void> {
+  return serviceCall('setPlayerPaidBy', async () => {
+    if (payerId === playerId)
+      throw new Error("A player cannot cover their own dues — use the Balance option instead");
+
+    const sessionRef = doc(refs.sessions, sessionId);
+    const payeeRef   = doc(refs.players, playerId);
+    const payerRef   = doc(refs.players, payerId);
+
+    await runTransaction(db, async (tx) => {
+      const sessionSnap = await tx.get(sessionRef);
+      if (!sessionSnap.exists()) throw new Error(`Session ${sessionId} not found`);
+
+      const players = sessionSnap.data().players as SessionPlayer[];
+      const target  = players.find(p => p.id === playerId);
+      if (!target) throw new Error(`Player ${playerId} not in session ${sessionId}`);
+
+      const cost = target.cost;
+      const currentVia: PaidVia =
+        target.paidVia ?? (target.comped ? 'comp' : target.paid ? 'etransfer' : null);
+      const oldPayerId = currentVia === 'transfer' ? (target.paidBy ?? null) : null;
+      if (currentVia === 'transfer' && oldPayerId === payerId) return; // no change
+
+      const oldPayerRef = oldPayerId && oldPayerId !== payerId ? doc(refs.players, oldPayerId) : null;
+      const [payeeSnap, payerSnap, oldPayerSnap] = await Promise.all([
+        tx.get(payeeRef),
+        tx.get(payerRef),
+        oldPayerRef ? tx.get(oldPayerRef) : Promise.resolve(null),
+      ]);
+      if (!payeeSnap.exists()) throw new Error(`Player ${playerId} not found`);
+      if (!payerSnap.exists()) throw new Error(`Paying player ${payerId} not found`);
+
+      // ── Reverse the payee's current settlement ──────────────────────────────────
+      // Wallet-neutral payout reversal for a prior e-Transfer/comp.
+      if (currentVia === 'etransfer' || currentVia === 'comp') {
+        tx.set(doc(refs.balanceLedger), {
+          playerId, sessionId,
+          delta:         -cost,
+          balanceBefore: 0,
+          balanceAfter:  0,
+          reason:        currentVia === 'etransfer' ? 'payment' : 'comp',
+          note:          currentVia === 'etransfer' ? 'Reversed e-Transfer payment' : 'Reversed comp',
+          createdAt:     serverTimestamp(),
+        });
+      }
+
+      // Refund the payee's own prepaid balance if they'd settled from it.
+      if (currentVia === 'balance') {
+        const payeeBefore = (payeeSnap.data()?.balance as number) ?? 0;
+        tx.update(payeeRef, { balance: increment(cost) });
+        tx.set(doc(refs.balanceLedger), {
+          playerId, sessionId,
+          delta:         cost,
+          balanceBefore: payeeBefore,
+          balanceAfter:  payeeBefore + cost,
+          reason:        'settlement',
+          note:          'Refunded prepaid balance',
+          createdAt:     serverTimestamp(),
+        });
+      }
+
+      // If a *different* player previously covered this, refund them.
+      if (oldPayerRef && oldPayerSnap?.exists()) {
+        const p = (oldPayerSnap.data()?.balance as number) ?? 0;
+        tx.update(oldPayerRef, { balance: increment(cost) });
+        tx.set(doc(refs.balanceLedger), {
+          playerId:      oldPayerId as string,
+          sessionId,
+          delta:         cost,
+          balanceBefore: p,
+          balanceAfter:  p + cost,
+          reason:        'settlement',
+          note:          'Refunded — no longer covering another player',
+          createdAt:     serverTimestamp(),
+        });
+      }
+
+      // The payee no longer owes the club (if they were unsettled).
+      if (currentVia === null) tx.update(payeeRef, { owed: increment(-cost) });
+
+      // ── Draw the new payer's balance ────────────────────────────────────────────
+      const payeeData = payeeSnap.data() as { firstName?: string; lastName?: string } | undefined;
+      const payeeName = [payeeData?.firstName, payeeData?.lastName].filter(Boolean).join(' ') || 'another player';
+      const payerBefore = (payerSnap.data()?.balance as number) ?? 0;
+      tx.update(payerRef, { balance: increment(-cost) });
+      tx.set(doc(refs.balanceLedger), {
+        playerId:      payerId,
+        sessionId,
+        delta:         -cost,
+        balanceBefore: payerBefore,
+        balanceAfter:  payerBefore - cost,
+        reason:        'session',
+        note:          `Covered ${payeeName}'s dues`,
+        createdAt:     serverTimestamp(),
+      });
+
+      // ── Mark the payee settled via transfer ─────────────────────────────────────
+      const updatedPlayers = players.map(p =>
+        p.id === playerId
+          ? { ...p, paid: true, comped: false, paidVia: 'transfer' as const, paidBy: payerId }
+          : p
+      );
+      tx.update(sessionRef, { players: updatedPlayers });
     });
   });
 }
@@ -660,11 +876,20 @@ export async function deleteSession(sessionId: string): Promise<void> {
       const courtUsage  = session.courtCreditUsage ?? [];
       const players     = session.players ?? [];
 
-      const [birdieSnaps, courtSnaps, playerSnaps] = await Promise.all([
+      // Players who covered others' dues from their balance ('transfer') must be
+      // refunded even when they aren't participants themselves.
+      const payerIds = players
+        .filter(p => p.paidVia === 'transfer' && p.paidBy)
+        .map(p => p.paidBy as string);
+      const balanceIds = [...new Set([...players.map(p => p.id), ...payerIds])];
+
+      const [birdieSnaps, courtSnaps, balanceSnaps] = await Promise.all([
         Promise.all(birdieUsage.map(u => tx.get(doc(refs.birdieInventory, u.id)))),
         Promise.all(courtUsage.map(u  => tx.get(doc(refs.courtCredits, u.id)))),
-        Promise.all(players.map(p     => tx.get(doc(refs.players, p.id)))),
+        Promise.all(balanceIds.map(id => tx.get(doc(refs.players, id)))),
       ]);
+      const playerSnapMap = new Map(balanceIds.map((id, i) => [id, balanceSnaps[i]]));
+      const playerSnaps = players.map(p => playerSnapMap.get(p.id)!);
 
       // Refund birds to each batch.
       birdieUsage.forEach((u, i) => {
@@ -726,6 +951,29 @@ export async function deleteSession(sessionId: string): Promise<void> {
             createdAt:     serverTimestamp(),
           });
         }
+      });
+
+      // Refund each payer who covered another player's dues from their balance.
+      const transferRefund = new Map<string, number>();
+      players.forEach(p => {
+        if (p.paidVia === 'transfer' && p.paidBy)
+          transferRefund.set(p.paidBy, (transferRefund.get(p.paidBy) ?? 0) + p.cost);
+      });
+      transferRefund.forEach((amount, id) => {
+        const snap = playerSnapMap.get(id);
+        if (!snap?.exists()) return;
+        const before = (snap.data()?.balance as number) ?? 0;
+        tx.update(snap.ref, { balance: increment(amount) });
+        tx.set(doc(refs.balanceLedger), {
+          playerId:      id,
+          sessionId,
+          delta:         amount,
+          balanceBefore: before,
+          balanceAfter:  before + amount,
+          reason:        'session-deleted',
+          note:          'Session deleted — refunded covered dues',
+          createdAt:     serverTimestamp(),
+        });
       });
 
       // Archive a copy, then delete the original.

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -41,10 +41,11 @@ export interface Session {
 
 // How a player's session cost was settled:
 //  'etransfer' — paid the club directly by e-Transfer (owed to the owner, counts in payout)
-//  'balance'   — drawn from the player's prepaid balance at session time
+//  'balance'   — drawn from the player's own prepaid balance at session time
+//  'transfer'  — drawn from *another* player's prepaid balance (see SessionPlayer.paidBy)
 //  'comp'      — settled directly with the owner (excluded from payout)
 //  null        — unpaid / owing
-export type PaidVia = 'etransfer' | 'balance' | 'comp' | null;
+export type PaidVia = 'etransfer' | 'balance' | 'transfer' | 'comp' | null;
 
 // Minimal — names are resolved from the Redux players slice, never stored in sessions
 export interface SessionPlayer {
@@ -53,6 +54,7 @@ export interface SessionPlayer {
   cost: number;
   paid: boolean;
   paidVia?: PaidVia; // how `paid`/`comped` was settled; disambiguates balance accounting
+  paidBy?: string | null; // when paidVia === 'transfer', the id of the player whose balance covered this cost
   comped?: boolean; // player settled directly with the owner — excluded from owner payout
   highlighted: boolean;
 }


### PR DESCRIPTION
Adds a 'transfer' settlement method: a player's session cost can be drawn from another player's prepaid balance, set via a 'Paid by' dropdown in the session view and the players page settlement stacks.

- types: add 'transfer' to PaidVia and paidBy to SessionPlayer
- sessions service: setPlayerPaidBy + transfer-aware setPlayerSettlement, addSession/editSession/deleteSession balance accounting and refunds
- ledger note names the covered player
- remove the unused highlight/star button; taller players sessions list